### PR TITLE
Change Versions that may be removed by removing 1.16.3 (v1_16_R2)

### DIFF
--- a/docs/BedWars1058/compatibility.md
+++ b/docs/BedWars1058/compatibility.md
@@ -8,7 +8,7 @@ BedWars1058 is made for [spigot](https://www.spigotmc.org/) but it works also on
 ### Supported versions
 * **1.8.8** (v1_8_R3)
 * **1.12 - 1.12.1 - 1.12.2** (v1_12_R1)
-* **1.16.4** (v1_16_R2)
+* **1.16.4/5** (v1_16_R3)
 * **1.17.1** (v1_17_R1)
 * **1.18.1** (v1_18_R1)
 
@@ -20,7 +20,7 @@ These versions are supported, but may be removed in the future
 * **1.13.1 - 1.13.2** (v1_13_R2)
 * **1.14 - 1.14.2** (v1_14_R1)
 * **1.15 - 1.15.2** (v1_15_R1)
-* **1.16.1 - 1.16.2** (v1_16_R1)
+* **1.16.1 - 1.16.3** (v1_16_R1/2)
 
 ## Known issues  
 - If you're running your server on **FoxSpigot** and you can't pick up items from generators set `stack-items: true` in `generators.yml`  


### PR DESCRIPTION
1.16.4 and 1.16.5 will be the only supported 1.16 based versions

(According to bstats no one uses 1.16.3 anyways)