### PR TITLE
Added Bedwars1058-Voidless & AdminAddon to addons.md

### DIFF
--- a/docs/BedWars1058/addons.md
+++ b/docs/BedWars1058/addons.md
@@ -32,6 +32,7 @@ If you have issues with the addon, it will probably be better to go to any suppo
 - [Bedwars1058 winstreak - Track winstreaks](https://www.spigotmc.org/resources/bedwars1058-winstreak-addon-sqlite-mysql.97509/)
 - [CloudNet Support Addon](https://www.spigotmc.org/resources/bedwars1058-cloudnet-addon.100041/) - by savalet
 - [♻️ Swappage - Swap to your opponent's team with ease](https://www.spigotmc.org/resources/swappage-bedwars1058-addon.102551/) - by [Tofpu](https://github.com/Tofpu)
+- [🍇 Bedwars Voidless - Adds the auto-bed defense feature to voidless mode](https://polymart.org/resource/bedwars1058-voidless-addon.2599/) - by Zuyte
 
 ## Pre-made setups
 

--- a/docs/BedWars1058/addons.md
+++ b/docs/BedWars1058/addons.md
@@ -33,6 +33,7 @@ If you have issues with the addon, it will probably be better to go to any suppo
 - [CloudNet Support Addon](https://www.spigotmc.org/resources/bedwars1058-cloudnet-addon.100041/) - by savalet
 - [♻️ Swappage - Swap to your opponent's team with ease](https://www.spigotmc.org/resources/swappage-bedwars1058-addon.102551/) - by [Tofpu](https://github.com/Tofpu)
 - [🍇 Bedwars Voidless - Adds the auto-bed defense feature to voidless mode](https://polymart.org/resource/bedwars1058-voidless-addon.2599/) - by Zuyte
+- [⚒️ Bedwars AdminAddon - Admin & Troll features of Bedwars1058!](https://polymart.org/resource/bedwars1058-adminaddon.2684) - by Zuyte
 
 ## Pre-made setups
 


### PR DESCRIPTION
BW Voidless addon Adds the auto-bed defense feature to voidless mode
Can also be used for 1v1 practice gamemode

BW AdminAddon Adds admin & troll features ex. setteam, forcejoin, revive, cage, mlg & more!