### PR TITLE
PAF update

### DIFF
--- a/docs/BedWars1058/hooks/parties-hook.md
+++ b/docs/BedWars1058/hooks/parties-hook.md
@@ -12,15 +12,13 @@ If players make a party and then join a BedWars game, BedWars1058 will put them 
 Just install the Parties plugin on the BedWars server and that's it :smile:. You can additionally 
  configure the minimum party rank allowed to select an arena.
  
-## Parties & Friends by Simonsator
+## Party & Friends by Simonsator
  
-**BedWars1058** is providing [Parties & Friends Extended Edition for Spigot](https://www.spigotmc.org/resources/party-and-friends-extended-for-spigot-supports-1-7-1-18.11633/) and [Parties & Friends Extended Edition for Bungeecord/Velocity](https://www.spigotmc.org/resources/party-and-friends-extended-edition-for-bungeecord-velocity-supports-1-7-1-18.10123/) (by simonsator) support since version 22.3.4.
+**BedWars1058** is providing [Parties & Friends Extended Edition for Spigot](https://www.spigotmc.org/resources/party-and-friends-extended-for-spigot-supports-1-7-1-18.11633/) and [Parties & Friends NonExtended/Extended Edition for Bungeecord/Velocity](https://www.spigotmc.org/resources/party-and-friends-extended-edition-for-bungeecord-velocity-supports-1-7-1-18.10123/) (by simonsator) support since version 22.3.4.
  
-### Parties & Friends Extended Edition for Spigot:
+### Party & Friends Extended Edition for Spigot:
 Just install the Parties & Friends Extended Edition for Spigot plugin on the BedWars server and that's it :smile:.
 
-### Parties & Friends Extended Edition for Bungeecord/Velocity:
-Just install the Parties and Friends plugin on your Bungeecord or Velocity Server, and also install the [Party API](https://www.spigotmc.org/resources/spigot-party-api-for-party-and-friends-extended-redisbungee-required.39751/) on proxy & arena servers.  And follow the setup to link the Party API to bungee.  A redis server is required.
-
-### Parties & Friends for Bungeecord:
-We only Support the extended edition for Bungeecord/Velocity.
+### Party & Friends NonExtended/Extended Edition for Bungeecord/Velocity:
+Just install the Party and Friends plugin on your Bungeecord or Velocity Server, and also install the [Party API](https://www.spigotmc.org/resources/spigot-party-api-for-party-and-friends-extended-redisbungee-required.39751/) on proxy & arena servers.
+Follow this [PartyAndFriendsAPI wiki](https://github.com/Simonsator/Party-API-For-Spigot/wiki/Installation)


### PR DESCRIPTION
PartyAndFriends hook update:

- API now support also NonExtended version (only mysql-bridge)
- RedisServer is no longer needed (You can use mysql database)